### PR TITLE
Airmon-ng: Fixed error when running 'check kill' due to a return when…

### DIFF
--- a/scripts/airmon-ng
+++ b/scripts/airmon-ng
@@ -975,7 +975,7 @@ then
 	then
 		#if we are killing, tell scanProcesses that
 		scanProcesses "${2}"
-		return
+		exit
 	elif [ x"${1}" = "xstart" ]
 	then
 		#this stub can send scanProcesses the interface name


### PR DESCRIPTION
… it should have been an exit (since it's not in a function).

git-svn-id: http://svn.aircrack-ng.org/trunk@2560 28c6078b-6c39-48e3-add9-af49d547ecab